### PR TITLE
Add default port number

### DIFF
--- a/sslscanner.rb
+++ b/sslscanner.rb
@@ -270,7 +270,7 @@ opts = GetoptLong.new(
     ['-h', GetoptLong::REQUIRED_ARGUMENT]
 )
 
-options = {debug: false, check_cert: false}
+options = {debug: false, check_cert: false, port: 443}
 
 opts.each do |opt, arg|
     case opt


### PR DESCRIPTION
Added 443 as a default port for this check. (most of the sites uses 443 as the SSL/TLS port)
